### PR TITLE
修复安卓8.x以上通知不显示

### DIFF
--- a/app/src/main/java/com/kooritea/mpush/service/SocketManagerService.java
+++ b/app/src/main/java/com/kooritea/mpush/service/SocketManagerService.java
@@ -3,12 +3,14 @@ package com.kooritea.mpush.service;
 
 import android.app.AlarmManager;
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.app.TaskStackBuilder;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
@@ -57,9 +59,26 @@ public class SocketManagerService extends Service {
         }
     }
 
+    private void createNotificationChannel() {
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = getString(R.string.channel_name);
+            String description = getString(R.string.channel_description);
+            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+            NotificationChannel channel = new NotificationChannel("channel_id", name, importance);
+            channel.setDescription(description);
+            // Register the channel with the system; you can't change the importance
+            // or other notification behaviors after this
+            NotificationManager notificationManager = getSystemService(NotificationManager.class);
+            notificationManager.createNotificationChannel(channel);
+        }
+    }
+
     @Override
     public void onCreate() {
         super.onCreate();
+        createNotificationChannel();
         cachedThreadPool = Executors.newCachedThreadPool();
         settingManager = SettingManager.create(this);
         mpushWSClient = new MpushWSClient(settingManager.get("URL"),settingManager.get("TOKEN"),settingManager.get("NAME"),settingManager.get("GROUP"),10000,this);
@@ -82,8 +101,9 @@ public class SocketManagerService extends Service {
 
 
     private void pushNotification(Message message){
-        NotificationCompat.Builder builder =  new NotificationCompat.Builder(this);
+        NotificationCompat.Builder builder =  new NotificationCompat.Builder(this, "channel_id");
         builder.setSmallIcon(R.mipmap.ic_launcher);
+        builder.setPriority(NotificationCompat.PRIORITY_DEFAULT);
         switch(message.getViewType()){
             case 1:
                 builder.setContentTitle(message.getData().getText());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
     <string name="app_name">Mpush</string>
     <string name="tab_text_1">消息</string>
     <string name="tab_text_2">送信</string>
+    <string name="channel_name">Notification</string>
+    <string name="channel_description">None</string>
 </resources>


### PR DESCRIPTION
 安卓8.x以上版本需要注册消息channel，不然会忽略通知，
在应用启动时创建消息渠道，并设置消息优先级以支持 Android 7.1 和更低版本。